### PR TITLE
Patch fixed net-dns issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "http://rubygems.org"
 
 gem "rspec"
 gem "flexmock"
-gem "net-dns"
+gem "net-dns2"

--- a/lib/project-honeypot.rb
+++ b/lib/project-honeypot.rb
@@ -1,4 +1,4 @@
-require 'net/dns/resolver'
+require 'net/dns'
 require File.dirname(__FILE__) + "/project_honeypot/url.rb"
 require File.dirname(__FILE__) + "/project_honeypot/base.rb"
 

--- a/project-honeypot.gemspec
+++ b/project-honeypot.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = %q{project-honeypot}
-  s.version = "0.1.1"
-  s.date = %q{2010-10-22}
+  s.version = "0.1.2"
+  s.date = %q{2015-07-02}
   s.authors = ["Charles Max Wood"]
   s.email = %q{chuck@teachmetocode.com}
   s.summary = %q{Project-Honeypot provides a programatic interface to the Project Honeypot services.}

--- a/project-honeypot.gemspec
+++ b/project-honeypot.gemspec
@@ -1,13 +1,13 @@
 Gem::Specification.new do |s|
   s.name = %q{project-honeypot}
-  s.version = "0.1.2"
+  s.version = "0.1.3"
   s.date = %q{2015-07-02}
   s.authors = ["Charles Max Wood"]
   s.email = %q{chuck@teachmetocode.com}
   s.summary = %q{Project-Honeypot provides a programatic interface to the Project Honeypot services.}
   s.homepage = %q{http://teachmetocode.com/}
   s.description = %q{Project-Honeypot provides a programatic interface to the Project Honeypot services. It can be used to identify spammers, bogus commenters, and harvesters. You will need a FREE api key from http://projecthoneypot.org}
-  s.add_dependency('net-dns')
+  s.add_dependency('net-dns2')
   s.files = [ "README.rdoc", 
               "MIT-LICENSE", 
               "lib/project-honeypot.rb",


### PR DESCRIPTION
the current gem has been causing the following error with net-dns:
uninitialized constant Net::DNS::A

This patch switches to net-dns2 and resolves it and ups the version number.
